### PR TITLE
fix typo

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,5 +13,5 @@ deployments:
                     filename: pan-domain-lamda.zip
                     name: pan-domain-lambda-CODE-Lambda-EY6RANAESX82
                 PROD:
-                    filename: pan-domain-lambda.zip
+                    filename: pan-domain-lamda.zip
                     name: pan-domain-lambda-PROD-Lambda-AHG6279NB84Y


### PR DESCRIPTION
An initial typo in the project name which I tried to replicate everywhere was missing in the zip file name and the lambda couldn't be deployed on prod. 